### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pylint
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/DenysMenfredy/genetic_algorithms/security/code-scanning/1](https://github.com/DenysMenfredy/genetic_algorithms/security/code-scanning/1)

To address the issue, add a `permissions` key at the root level of the workflow file. Since this is a minimal workflow that primarily installs dependencies, analyzes code with Pylint, and does not seem to interact with GitHub resources in a way that requires write access, the `contents: read` permission is sufficient. This explicitly limits the permissions of the `GITHUB_TOKEN` to the minimal level required.

The changes involve adding the `permissions` block right after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
